### PR TITLE
Adding basic dockerfile for jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+#Using alpine base image
+FROM alpine:latest
+
+#Installing jq and setting up the working directory
+RUN apk update && apk add jq && rm -rf /var/cache/apk/* && mkdir /app
+WORKDIR  /app
+
+# docker build --file=./Dockerfile  -t jq .
+# docker run -it jq


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/69343990/207332379-2a378a41-79b7-4906-b48d-c046e7a6cce5.png)

Docker image with alpine as base image, efficient and smaller in size as compared to openjdk with same functionality